### PR TITLE
add k6 load test files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# ignore log files that will be generated
+k6/*-logs.txt
+
+# ignore a nodeJS files that can help during test development (e.g. install @types/k6 as dev dependency)
+k6/tests/package.json
+k6/tests/package-lock.json
+k6/tests/node_modules

--- a/k6/README.md
+++ b/k6/README.md
@@ -1,0 +1,21 @@
+# Load Test for the Kubernetes API with k6
+
+## Description
+
+This folder contains some Kubernetes resources and a script to start load tests against the Kubernetes API.
+
+## How does it work?
+
+Under the surface we're using [k6](https://k6.io/) as load testing. It's written in Go but the tests are written in JavaScript. You can either check existing tests or read the [documentation(https://k6.io/docs/)]. Existing tests are in the `tests/` subfolder.
+
+To start the tests you can use the `start.sh` script and provide three paremeters:
+
+1. the script you want to execute (e.g. tests/my-test.js)
+2. the number of concurrent "users" (in k6 they're called virtual users or vus)
+3. the number of overall iterations (they will be distributed across the number of vus)
+
+This will spin up a new namespace (`load-test`) in the target cluster with a service account that has cluster-admin role permissions and will spawn k6 with the script you provided. The test file is mounted to the pod from a ConfigMap. Afterwards it will grab the logs from the pod and clean everything up. The logs will be stored in your current folder.
+
+## Misc
+
+There is already a util.js file you can use with some custom helper functions (like get the current namespace, build the Kubernetes API base URL etc.)

--- a/k6/job.yaml
+++ b/k6/job.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: load-test
+spec:
+  template:
+    spec:
+      serviceAccountName: load-test
+      containers:
+        - image: grafana/k6:0.45.0
+          resources: {}
+          name: k6
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              k6 run /script/script.js --summary-export=summary.json --no-usage-report
+              echo "============== STRIP =============="
+              cat summary.json
+          env:
+            - name: KUBERNETES_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-token
+                  key: token
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            # this is needed for custom or private CA's
+            # there is no support for custom CA certs: https://github.com/grafana/k6/issues/218
+            - name: K6_INSECURE_SKIP_TLS_VERIFY
+              value: "true"
+            - name: K6_VUS
+              valueFrom:
+                configMapKeyRef:
+                  name: load-test
+                  key: vus
+            - name: K6_ITERATIONS
+              valueFrom:
+                configMapKeyRef:
+                  name: load-test
+                  key: iterations
+          volumeMounts:
+            - name: script
+              mountPath: /script
+      volumes:
+        - name: script
+          configMap:
+            name: load-test
+            items:
+              - key: util.js
+                path: util.js
+              - key: script.js
+                path: script.js
+      restartPolicy: OnFailure

--- a/k6/rbac.yaml
+++ b/k6/rbac.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: load-test
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: load-test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: load-test
+  namespace: load-test
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: load-test-token
+  annotations:
+      kubernetes.io/service-account.name: load-test
+type: kubernetes.io/service-account-token

--- a/k6/start.sh
+++ b/k6/start.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+NAMESPACE="load-test"
+
+if [[ $# -lt 3 ]]; then
+	echo "Usage: $0 <script> <vus> <iterations>" 1>&2
+	echo "Example: $0 tests/my-test.js 10 100" 1>&2
+	exit 1
+fi
+
+SCRIPT="$1"
+VUS="$2"
+ITERATIONS="$3"
+
+if [[ $ITERATIONS -lt $VUS ]]; then
+	echo "iterations must be greater or equal to vus" 1>&2
+	exit 1
+fi
+
+echo "Deploying namespace..."
+kubectl create ns "$NAMESPACE"
+
+echo "Deploying RBAC..."
+kubectl apply -n "$NAMESPACE" -f rbac.yaml
+
+# copy the script to a temp file under a common name
+# so that we can reference always to the same name in the pod
+SCRIPT_DIR=$(mktemp -d)
+NEW_SCRIPT_PATH="${SCRIPT_DIR}/script.js"
+
+cp "$SCRIPT" "$NEW_SCRIPT_PATH"
+
+echo "Creating configmap..."
+kubectl create configmap -n "$NAMESPACE" load-test --from-file="tests/util.js" --from-file="$NEW_SCRIPT_PATH" --from-literal="vus=$VUS" --from-literal="iterations=$ITERATIONS"
+
+rm -rf "$SCRIPT_DIR"
+
+echo "Deploying k6 job..."
+kubectl apply -n "$NAMESPACE" -f job.yaml
+
+echo "Waiting for the job to be completed..."
+kubectl wait -n "$NAMESPACE" --for=condition=complete --timeout=600s jobs/load-test
+
+echo "Extracting logs and summary..."
+kubectl logs -n "$NAMESPACE" jobs/load-test > "$(basename "$SCRIPT")-${VUS}vu-${ITERATIONS}it-logs.txt"
+
+echo "Clean up job and configmap..."
+kubectl delete -n "$NAMESPACE" jobs load-test
+kubectl delete -n "$NAMESPACE" configmap load-test
+kubectl delete clusterrolebinding load-test
+
+echo "Clean up..."
+kubectl delete ns "$NAMESPACE"

--- a/k6/tests/kyverno-configmap-dry-run.js
+++ b/k6/tests/kyverno-configmap-dry-run.js
@@ -1,0 +1,18 @@
+import http from 'k6/http';
+import { check } from 'k6';
+import { buildKubernetesBaseUrl, generateConfigmap, getParamsWithAuth, getTestNamespace } from './util.js';
+
+const baseUrl = buildKubernetesBaseUrl();
+const namespace = getTestNamespace();
+
+export default function () {
+  const cm = generateConfigmap();
+
+  const params = getParamsWithAuth();
+  params.headers['Content-Type'] = 'application/json';
+
+  const res = http.post(`${baseUrl}/api/v1/namespaces/${namespace}/configmaps?dryRun=All`, JSON.stringify(cm), params);
+  check(res, {
+    'verify response code is 201': r => r.status === 201
+  })
+}

--- a/k6/tests/kyverno-pods-dry-run.js
+++ b/k6/tests/kyverno-pods-dry-run.js
@@ -1,0 +1,18 @@
+import http from 'k6/http';
+import { check } from 'k6';
+import { buildKubernetesBaseUrl, generatePod, getParamsWithAuth, getTestNamespace } from './util.js';
+
+const baseUrl = buildKubernetesBaseUrl();
+const namespace = getTestNamespace();
+
+export default function () {
+  const pod = generatePod();
+
+  const params = getParamsWithAuth();
+  params.headers['Content-Type'] = 'application/json';
+
+  const res = http.post(`${baseUrl}/api/v1/namespaces/${namespace}/pods?dryRun=All`, JSON.stringify(pod), params);
+  check(res, {
+    'verify response code is 201': r => r.status === 201
+  })
+}

--- a/k6/tests/kyverno-pods.js
+++ b/k6/tests/kyverno-pods.js
@@ -1,0 +1,30 @@
+import http from 'k6/http';
+import { check } from 'k6';
+import { buildKubernetesBaseUrl, generatePod, getParamsWithAuth, getTestNamespace, randomString } from './util.js';
+
+const baseUrl = buildKubernetesBaseUrl();
+const namespace = getTestNamespace();
+
+export default function() {
+  const podName = `test-${randomString(8)}`;
+  const pod = generatePod(podName);
+  pod.metadata.labels = {
+    app: 'k6-test'
+  }
+
+  const params = getParamsWithAuth();
+  params.headers['Content-Type'] = 'application/json';
+
+  const createRes = http.post(`${baseUrl}/api/v1/namespaces/${namespace}/pods`, JSON.stringify(pod), params);
+  check(createRes, {
+    'verify response code of POST is 201': r => r.status === 201
+  });
+}
+
+export function teardown() {
+  const params = getParamsWithAuth();
+  const deleteRes = http.del(`${baseUrl}/api/v1/namespaces/${namespace}/pods?labelSelector=app=k6-test`, null, params);
+  check(deleteRes, {
+    'verify response code of DELETE is 200': r => r.status === 200
+  });
+}

--- a/k6/tests/kyverno-secret-dry-run.js
+++ b/k6/tests/kyverno-secret-dry-run.js
@@ -1,0 +1,18 @@
+import http from 'k6/http';
+import { check } from 'k6';
+import { buildKubernetesBaseUrl, generateSecret, getParamsWithAuth, getTestNamespace } from './util.js';
+
+const baseUrl = buildKubernetesBaseUrl();
+const namespace = getTestNamespace();
+
+export default function () {
+  const secret = generateSecret();
+
+  const params = getParamsWithAuth();
+  params.headers['Content-Type'] = 'application/json';
+
+  const res = http.post(`${baseUrl}/api/v1/namespaces/${namespace}/secrets?dryRun=All`, JSON.stringify(secret), params);
+  check(res, {
+    'verify response code is 201': r => r.status === 201
+  })
+}

--- a/k6/tests/util.js
+++ b/k6/tests/util.js
@@ -1,0 +1,65 @@
+export const generatePod = (name = 'test', image = 'alpine') => {
+  return {
+    kind: 'Pod',
+    apiVersion: 'v1',
+    metadata: {
+      name: name,
+    },
+    spec: {
+      containers: [
+        {
+          name: 'test',
+          image,
+        }
+      ],
+    }
+  }
+}
+
+export const generateConfigmap = (name = 'test') => {
+  return {
+    kind: "ConfigMap",
+    apiVersion: "v1",
+    metadata: {
+      name: name
+    }
+  }
+}
+
+export const generateSecret = (name = 'test') => {
+  return {
+    kind: "Secret",
+    apiVersion: "v1",
+    metadata: {
+      name: name
+    }
+  }
+}
+
+export const buildKubernetesBaseUrl = () => {
+  return `https://${__ENV.KUBERNETES_SERVICE_HOST}:${__ENV.KUBERNETES_SERVICE_PORT}`;
+}
+
+export const getTestNamespace = () => {
+  return __ENV.POD_NAMESPACE;
+}
+
+export const getParamsWithAuth = () => {
+  return {
+    headers: {
+      'Authorization': `Bearer ${__ENV.KUBERNETES_TOKEN}`
+    }
+  }
+}
+
+export const randomString = (length) => {
+  const characters = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  const charactersLength = characters.length;
+  let result = '';
+  let counter = 0;
+  while (counter < length) {
+    result += characters.charAt(Math.floor(Math.random() * charactersLength));
+    counter += 1;
+  }
+  return result;
+}


### PR DESCRIPTION
This PR adds some files that will start load tests from within the cluster against the Kube API. It uses k6 under the hood.