### PR TITLE
ci: return exit code for CI automation

### DIFF
--- a/k6/job.yaml
+++ b/k6/job.yaml
@@ -3,29 +3,37 @@ kind: Job
 metadata:
   name: load-test
 spec:
+  podFailurePolicy:
+    rules:
+      - action: FailJob
+        onExitCodes:
+          containerName: k6
+          operator: In
+          values: [99]
+      - action: Ignore
+        onPodConditions:
+          - type: DisruptionTarget
   template:
     spec:
       serviceAccountName: load-test
       containers:
-        - image: grafana/k6:0.45.0
+        - image: grafana/k6:0.48.0
           resources: {}
           name: k6
           securityContext:
             allowPrivilegeEscalation: false
-            runAsNonRoot: true
+            runAsUser: 12345
             seccompProfile:
               type: RuntimeDefault
             capabilities:
               drop:
-              - ALL
+                - ALL
           command:
-            - /bin/sh
-            - -c
+            - k6
           args:
-            - |
-              k6 run /script/script.js --summary-export=summary.json --no-usage-report
-              echo "============== STRIP =============="
-              cat summary.json
+            - run
+            - /script/script.js
+            - --no-usage-report
           env:
             - name: KUBERNETES_TOKEN
               valueFrom:
@@ -62,4 +70,4 @@ spec:
                 path: util.js
               - key: script.js
                 path: script.js
-      restartPolicy: OnFailure
+      restartPolicy: Never

--- a/k6/rbac.yaml
+++ b/k6/rbac.yaml
@@ -14,7 +14,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: load-test
-  namespace: load-test
+  namespace: load-tests
 ---
 apiVersion: v1
 kind: Secret

--- a/k6/tests/kyverno-generate.js
+++ b/k6/tests/kyverno-generate.js
@@ -12,8 +12,8 @@ import {
 
 // export const options = {
 //   thresholds: {
-//     // 90% of requests should be below 200ms
-//     http_req_duration: ["p(90)<200"],
+//     // 90% of requests should be below 600ms
+//     http_req_duration: ["p(90)<600"],
 //   },
 // };
 
@@ -24,20 +24,32 @@ const params = getParamsWithAuth();
 params.headers["Content-Type"] = "application/json";
 
 export function setup() {
-  const mutatePolicy = {
+  const generatePolicy = {
     apiVersion: "kyverno.io/v1",
     kind: "ClusterPolicy",
-    metadata: { name: "add-labels" },
+    metadata: { name: "zk-kafka-address" },
     spec: {
       rules: [
         {
-          match: { any: [{ resources: { kinds: ["Pod"] } }] },
-          mutate: {
-            patchStrategicMerge: {
-              metadata: { labels: { "+(team)": "bravo" } },
+          generate: {
+            apiVersion: "v1",
+            data: {
+              data: {
+                KAFKA_ADDRESS:
+                  "192.168.10.13:9092,192.168.10.14:9092,192.168.10.15:9092",
+                ZK_ADDRESS:
+                  "192.168.10.10:2181,192.168.10.11:2181,192.168.10.12:2181",
+              },
+              kind: "ConfigMap",
+              metadata: { labels: { app: "k6-test" } },
             },
+            kind: "ConfigMap",
+            name: "{{request.object.metadata.name}}",
+            namespace: namespace,
+            synchronize: true,
           },
-          name: "add-team",
+          match: { any: [{ resources: { kinds: ["Pod"] } }] },
+          name: "k-kafka-address",
         },
       ],
     },
@@ -45,7 +57,7 @@ export function setup() {
 
   const createRes = http.post(
     `${baseUrl}/apis/kyverno.io/v1/clusterpolicies`,
-    JSON.stringify(mutatePolicy),
+    JSON.stringify(generatePolicy),
     params
   );
 
@@ -57,9 +69,23 @@ export function setup() {
 export default function () {
   const podName = `test-${randomString(8)}`;
 
-  const pod = generatePod(podName);
-  pod.metadata.labels = {
-    app: "k6-test",
+  const pod = {
+    kind: "Pod",
+    apiVersion: "v1",
+    metadata: {
+      name: podName,
+      labels: {
+        app: "k6-test",
+      },
+    },
+    spec: {
+      containers: [
+        {
+          name: "test",
+          image: "nginx",
+        },
+      ],
+    },
   };
 
   const createRes = http.post(
@@ -71,11 +97,23 @@ export default function () {
   check(createRes, {
     "verify response code of POST is 201": (r) => r.status === 201,
   });
+
+  let getRes;
+  do {
+    getRes = http.get(
+      `${baseUrl}/api/v1/namespaces/${namespace}/configmaps/${podName}`,
+      params
+    );
+  } while (getRes.status !== 200);
+
+  check(getRes, {
+    "verify response code of GET is 200": (r) => r.status === 200,
+  });
 }
 
 export function teardown() {
   const deleteRes = http.del(
-    `${baseUrl}/apis/kyverno.io/v1/clusterpolicies/add-labels`,
+    `${baseUrl}/apis/kyverno.io/v1/clusterpolicies/zk-kafka-address`,
     null,
     params
   );

--- a/k6/tests/kyverno-generate.js
+++ b/k6/tests/kyverno-generate.js
@@ -10,13 +10,6 @@ import {
   randomString,
 } from "./util.js";
 
-// export const options = {
-//   thresholds: {
-//     // 90% of requests should be below 600ms
-//     http_req_duration: ["p(90)<600"],
-//   },
-// };
-
 const baseUrl = buildKubernetesBaseUrl();
 const namespace = getTestNamespace();
 

--- a/k6/tests/kyverno-mutate.js
+++ b/k6/tests/kyverno-mutate.js
@@ -10,13 +10,6 @@ import {
   randomString,
 } from "./util.js";
 
-// export const options = {
-//   thresholds: {
-//     // 90% of requests should be below 200ms
-//     http_req_duration: ["p(90)<200"],
-//   },
-// };
-
 const baseUrl = buildKubernetesBaseUrl();
 const namespace = getTestNamespace();
 

--- a/k6/tests/kyverno-mutate.js
+++ b/k6/tests/kyverno-mutate.js
@@ -1,0 +1,93 @@
+import http from "k6/http";
+import { check } from "k6";
+import { textSummary } from "https://jslib.k6.io/k6-summary/0.0.2/index.js";
+
+import {
+  buildKubernetesBaseUrl,
+  generatePod,
+  getParamsWithAuth,
+  getTestNamespace,
+  randomString,
+} from "./util.js";
+
+// export const options = {
+//   thresholds: {
+//     // 90% of requests should be below 600ms
+//     http_req_duration: ["p(90)<600"],
+//   },
+// };
+
+const baseUrl = buildKubernetesBaseUrl();
+const namespace = getTestNamespace();
+
+const params = getParamsWithAuth();
+params.headers["Content-Type"] = "application/json";
+
+export function setup() {
+  const mutatePolicy = {
+    apiVersion: "kyverno.io/v1",
+    kind: "ClusterPolicy",
+    metadata: { name: "add-labels" },
+    spec: {
+      rules: [
+        {
+          match: { any: [{ resources: { kinds: ["Pod"] } }] },
+          mutate: {
+            patchStrategicMerge: {
+              metadata: { labels: { "+(team)": "bravo" } },
+            },
+          },
+          name: "add-team",
+        },
+      ],
+    },
+  };
+
+  const createRes = http.post(
+    `${baseUrl}/apis/kyverno.io/v1/clusterpolicies`,
+    JSON.stringify(mutatePolicy),
+    params
+  );
+
+  check(createRes, {
+    "verify response code of POST is 201": (r) => r.status === 201,
+  });
+}
+
+export default function () {
+  const podName = `test-${randomString(8)}`;
+
+  const pod = generatePod(podName);
+  pod.metadata.labels = {
+    app: "k6-test",
+  };
+
+  const createRes = http.post(
+    `${baseUrl}/api/v1/namespaces/${namespace}/pods`,
+    JSON.stringify(pod),
+    params
+  );
+
+  check(createRes, {
+    "verify response code of POST is 201": (r) => r.status === 201,
+  });
+}
+
+export function teardown() {
+  const deleteRes = http.del(
+    `${baseUrl}/apis/kyverno.io/v1/clusterpolicies/add-labels`,
+    null,
+    params
+  );
+
+  check(deleteRes, {
+    "verify response code of DELETE is 200": (r) => r.status === 200,
+  });
+}
+
+export function handleSummary(data) {
+  return {
+    stdout: textSummary(data, { indent: " ", enableColors: false }),
+    "summary.json": JSON.stringify(data),
+  };
+}

--- a/k6/tests/kyverno-pss.js
+++ b/k6/tests/kyverno-pss.js
@@ -22,12 +22,12 @@ import {
   randomString,
 } from "./util.js";
 
-// export const options = {
-//   thresholds: {
-//     // 90% of requests should be below 600ms
-//     http_req_duration: ["p(90)<600"],
-//   },
-// };
+export const options = {
+  thresholds: {
+    // 90% of requests should be below 200ms
+    http_req_duration: ["p(90)<200"],
+  },
+};
 
 const baseUrl = buildKubernetesBaseUrl();
 const namespace = getTestNamespace();

--- a/k6/tests/kyverno-pss.js
+++ b/k6/tests/kyverno-pss.js
@@ -1,40 +1,65 @@
 /**
  * Test policy latency based on blocked requests.
- * 
+ *
  *    ./start.sh tests/kyverno-pss.js 500 2000
- * 
- * The start script will create Pod Security Standard policies using the Helm chart:  
- * 
+ *
+ * The start script will create Pod Security Standard policies using the Helm chart:
+ *
  *    https://artifacthub.io/packages/helm/kyverno/kyverno-policies
- * 
+ *
  * It then attempts to create insecure pods and measures the response times.
- * 
+ *
  */
-import http from 'k6/http';
-import { check } from 'k6';
-import { buildKubernetesBaseUrl, generatePod, getParamsWithAuth, getTestNamespace, randomString } from './util.js';
+import http from "k6/http";
+import { check } from "k6";
+import { textSummary } from "https://jslib.k6.io/k6-summary/0.0.2/index.js";
+
+import {
+  buildKubernetesBaseUrl,
+  generatePod,
+  getParamsWithAuth,
+  getTestNamespace,
+  randomString,
+} from "./util.js";
+
+// export const options = {
+//   thresholds: {
+//     // 90% of requests should be below 600ms
+//     http_req_duration: ["p(90)<600"],
+//   },
+// };
 
 const baseUrl = buildKubernetesBaseUrl();
 const namespace = getTestNamespace();
 
-export default function() {
+export default function () {
   const podName = `test-${randomString(8)}`;
   const pod = generatePod(podName);
   pod.metadata.labels = {
-    app: 'k6-test'
-  }
+    app: "k6-test",
+  };
 
   // clear the security context for insecure pods
-  pod.spec.containers[0].securityContext = {}
+  pod.spec.containers[0].securityContext = {};
 
   const params = getParamsWithAuth();
-  params.headers['Content-Type'] = 'application/json';
+  params.headers["Content-Type"] = "application/json";
 
-  const createRes = http.post(`${baseUrl}/api/v1/namespaces/${namespace}/pods`, JSON.stringify(pod), params);
+  const createRes = http.post(
+    `${baseUrl}/api/v1/namespaces/${namespace}/pods`,
+    JSON.stringify(pod),
+    params
+  );
   check(createRes, {
-    'verify response code of POST is 400': r => r.status === 400
+    "verify response code of POST is 400": (r) => r.status === 400,
   });
 }
 
-export function teardown() {
+export function teardown() {}
+
+export function handleSummary(data) {
+  return {
+    stdout: textSummary(data, { indent: " ", enableColors: false }),
+    "summary.json": JSON.stringify(data),
+  };
 }

--- a/k6/tests/kyverno-scale-testing.js
+++ b/k6/tests/kyverno-scale-testing.js
@@ -1,0 +1,114 @@
+import http from "k6/http";
+import { check } from "k6";
+import { textSummary } from "https://jslib.k6.io/k6-summary/0.0.2/index.js";
+
+import {
+  buildKubernetesBaseUrl,
+  generatePod,
+  getParamsWithAuth,
+  getTestNamespace,
+  randomString,
+} from "./util.js";
+
+export const options = {
+  discardResponseBodies: true,
+  scenarios: {
+    scale: {
+      executor: "constant-arrival-rate",
+
+      // How long the test lasts
+      duration: "120s",
+
+      // How many iterations per timeUnit
+      rate: 30,
+
+      // Start `rate` iterations per second
+      timeUnit: "1s",
+
+      // Pre-allocate VUs
+      preAllocatedVUs: 50,
+    },
+  },
+};
+
+const baseUrl = buildKubernetesBaseUrl();
+const namespace = getTestNamespace();
+
+const params = getParamsWithAuth();
+params.headers["Content-Type"] = "application/json";
+
+export function setup() {
+  const validatePolicy = {
+    apiVersion: "kyverno.io/v1",
+    kind: "ClusterPolicy",
+    metadata: {
+      annotations: {
+        "kubectl.kubernetes.io/last-applied-configuration":
+          '{"apiVersion":"kyverno.io/v1","kind":"ClusterPolicy","metadata":{"annotations":{},"name":"require-labels"},"spec":{"background":true,"rules":[{"match":{"any":[{"resources":{"kinds":["Pod"]}}]},"name":"check-team","validate":{"message":"label \'team\' is required","pattern":{"metadata":{"labels":{"team":"?*"}}}}}],"validationFailureAction":"Audit"}}\n',
+      },
+      name: "require-labels",
+    },
+    spec: {
+      background: true,
+      rules: [
+        {
+          match: { any: [{ resources: { kinds: ["Pod"] } }] },
+          name: "check-team",
+          validate: {
+            message: "label 'team' is required",
+            pattern: { metadata: { labels: { team: "?*" } } },
+          },
+        },
+      ],
+      validationFailureAction: "Audit",
+    },
+  };
+
+  const createRes = http.post(
+    `${baseUrl}/apis/kyverno.io/v1/clusterpolicies`,
+    JSON.stringify(validatePolicy),
+    params
+  );
+
+  check(createRes, {
+    "verify response code of POST is 201": (r) => r.status === 201,
+  });
+}
+
+export default function () {
+  const podName = `test-${randomString(8)}`;
+
+  const pod = generatePod(podName);
+  pod.metadata.labels = {
+    app: "k6-test",
+  };
+
+  const createRes = http.post(
+    `${baseUrl}/api/v1/namespaces/${namespace}/pods`,
+    JSON.stringify(pod),
+    params
+  );
+
+  check(createRes, {
+    "verify response code of POST is 201": (r) => r.status === 201,
+  });
+}
+
+export function teardown() {
+  const deleteRes = http.del(
+    `${baseUrl}/apis/kyverno.io/v1/clusterpolicies/require-labels`,
+    null,
+    params
+  );
+
+  check(deleteRes, {
+    "verify response code of DELETE is 200": (r) => r.status === 200,
+  });
+}
+
+export function handleSummary(data) {
+  return {
+    stdout: textSummary(data, { indent: " ", enableColors: false }),
+    "summary.json": JSON.stringify(data),
+  };
+}

--- a/k8s/metrics-server/components.yaml
+++ b/k8s/metrics-server/components.yaml
@@ -1,0 +1,192 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    k8s-app: metrics-server
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: system:aggregated-metrics-reader
+rules:
+  - apiGroups:
+      - metrics.k8s.io
+    resources:
+      - pods
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: system:metrics-server
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - nodes
+      - nodes/stats
+      - namespaces
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+  - kind: ServiceAccount
+    name: metrics-server
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: metrics-server
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: system:metrics-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:metrics-server
+subjects:
+  - kind: ServiceAccount
+    name: metrics-server
+    namespace: kube-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server
+  namespace: kube-system
+spec:
+  ports:
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: https
+  selector:
+    k8s-app: metrics-server
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: metrics-server
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        k8s-app: metrics-server
+    spec:
+      containers:
+        - args:
+            - --cert-dir=/tmp
+            - --secure-port=443
+            - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
+            - --kubelet-use-node-status-port
+            - --metric-resolution=15s
+          image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /livez
+              port: https
+              scheme: HTTPS
+            periodSeconds: 10
+          name: metrics-server
+          ports:
+            - containerPort: 443
+              name: https
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: https
+              scheme: HTTPS
+            initialDelaySeconds: 20
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 200Mi
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp-dir
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-cluster-critical
+      serviceAccountName: metrics-server
+      volumes:
+        - emptyDir: {}
+          name: tmp-dir
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: v1beta1.metrics.k8s.io
+spec:
+  group: metrics.k8s.io
+  groupPriorityMinimum: 100
+  insecureSkipTLSVerify: true
+  service:
+    name: metrics-server
+    namespace: kube-system
+  version: v1beta1
+  versionPriority: 100

--- a/k8s/metrics-server/hack.sh
+++ b/k8s/metrics-server/hack.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+set -eou pipefail
+
+PARENT_PATH=$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P)
+cd "$PARENT_PATH"
+
+kubectl apply -f components.yaml
+kubectl patch -n kube-system deployment metrics-server --type=json \
+  -p '[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--kubelet-insecure-tls"}]'


### PR DESCRIPTION
This PR mainly introduces two new changes.

First, we used to parse the output of K6 to determine whther it succeeded or not. This is not sustainable as it would mean we would ave to parse thresholds as well and react of the format changed. What We need is for the normal exit code to take effect. I have done this by making the script responsible for running the test return the same exit code as K6. Failing the Job only if the exit code is 99.

Lastly, I added two new tests. One for Mutate rules and one for Generate rules. I also added thresholds to make a reasonable assumption that requests should finish within 200 ms.

Finally some corrections. The K6 container runs as user `12345` and fixed the namespace name.