### PR TITLE
fix: add runAsNonRoot for k6 job

### DIFF
--- a/k6/job.yaml
+++ b/k6/job.yaml
@@ -23,6 +23,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             runAsUser: 12345
+            runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
             capabilities:


### PR DESCRIPTION
This PR adds runAsNonRoot to the k6 job to meet the restricted PSs policies.