### PR TITLE
added load tests for vpa

### DIFF
--- a/k6/tests/kyverno-vpa.js
+++ b/k6/tests/kyverno-vpa.js
@@ -1,0 +1,44 @@
+import http from "k6/http";
+import { check } from "k6";
+import { textSummary } from "https://jslib.k6.io/k6-summary/0.0.2/index.js";
+
+import {
+  buildKubernetesBaseUrl,
+  generatePod,
+  generateVPA,
+  getParamsWithAuth,
+  getTestNamespace,
+  randomString,
+} from "./util.js";
+
+
+
+const baseUrl = buildKubernetesBaseUrl();
+const namespace = getTestNamespace();
+
+export default function () {
+  const podName = `test-${randomString(8)}`;
+  const vpa = generateVPA(podName);
+    vpa.metadata.labels = {
+        app: "k6-test",
+    };
+    const params = getParamsWithAuth();
+    params.headers["Content-Type"] = "application/json";
+
+  const createVpaRes = http.post(
+    `${baseUrl}/apis/autoscaling.k8s.io/v1/namespaces/${namespace}/verticalpodautoscalers`,
+    JSON.stringify(vpa),
+    params
+  );
+  check(createVpaRes, {
+    "verify response code of POST VPA is 201": (r) => r.status === 201,
+  });
+}
+export function teardown() {}
+
+export function handleSummary(data) {
+  return {
+    stdout: textSummary(data, { indent: " ", enableColors: false }),
+    "summary.json": JSON.stringify(data),
+  };
+}

--- a/k6/tests/util.js
+++ b/k6/tests/util.js
@@ -28,6 +28,26 @@ export const generatePod = (name = 'test', image = 'nginx') => {
   }
 }
 
+export const generateVPA = (name = 'test-vpa', targetRefName = 'test', targetRefKind = 'Pod') => {
+  return {
+    kind: 'VerticalPodAutoscaler',
+    apiVersion: 'autoscaling.k8s.io/v1',
+    metadata: {
+      name: name,
+    },
+    spec: {
+      targetRef: {
+        apiVersion: 'v1',
+        kind: targetRefKind,
+        name: targetRefName,
+      },
+      updatePolicy: {
+        updateMode: 'Auto',
+      }
+    }
+  }
+}
+
 export const generateConfigmap = (name = 'test') => {
   return {
     kind: "ConfigMap",


### PR DESCRIPTION
adds load test by making post requests for the vpa 

output of  `kyverno-vpa.js-25vu-500it-logs.txt`

```
  execution: local
     script: /script/script.js
     output: -

  scenarios: (100.00%) 1 scenario, 25 max VUs, 10m30s max duration (incl. graceful stop):
           * default: 500 iterations shared among 25 VUs (maxDuration: 10m0s, gracefulStop: 30s)

     ✓ verify response code of POST VPA is 201

     █ teardown

     checks.........................: 100.00% ✓ 500        ✗ 0
     data_received..................: 437 kB  659 kB/s
     data_sent......................: 188 kB  284 kB/s
     http_req_blocked...............: avg=1.18ms   min=327ns   med=647ns   max=59.76ms p(90)=999ns    p(95)=370.63µs
     http_req_connecting............: avg=51.2µs   min=0s      med=0s      max=1.95ms  p(90)=0s       p(95)=7.14µs
     http_req_duration..............: avg=30.47ms  min=7.72ms  med=28.92ms max=72.06ms p(90)=38ms     p(95)=44.23ms
       { expected_response:true }...: avg=30.47ms  min=7.72ms  med=28.92ms max=72.06ms p(90)=38ms     p(95)=44.23ms
     http_req_failed................: 0.00%   ✓ 0          ✗ 500
     http_req_receiving.............: avg=439.68µs min=26.3µs  med=76.77µs max=16.69ms p(90)=920.41µs p(95)=2.41ms
     http_req_sending...............: avg=312.2µs  min=45.37µs med=80.72µs max=28.97ms p(90)=544.57µs p(95)=1.07ms
     http_req_tls_handshaking.......: avg=1.07ms   min=0s      med=0s      max=53.6ms  p(90)=0s       p(95)=292.54µs
     http_req_waiting...............: avg=29.72ms  min=7.6ms   med=28.53ms max=67.71ms p(90)=36.72ms  p(95)=43.3ms
     http_reqs......................: 500     753.227004/s
     iteration_duration.............: avg=32.3ms   min=2.08µs  med=29.66ms max=91.97ms p(90)=43.73ms  p(95)=54.22ms
     iterations.....................: 500     753.227004/s
running (00m00.7s), 00/25 VUs, 500 complete and 0 interrupted iterations
default ✓ [ 100% ] 25 VUs  00m00.7s/10m0s  500/500 shared iters
```
