### PR TITLE
chore: wait for pss policies to be ready before proceeding

### DIFF
--- a/k6/start.sh
+++ b/k6/start.sh
@@ -24,6 +24,7 @@ if [[ $SCRIPT == *"kyverno-pss.js" ]]; then
 	echo "installing PSS policies" 1>&2
 	helm repo add kyverno https://kyverno.github.io/kyverno/
 	helm install kyverno-policies --namespace kyverno-policies kyverno/kyverno-policies --create-namespace -f pss-values.yml
+	kubectl wait --for=condition=Ready --timeout=120s cpol -l app.kubernetes.io/name=kyverno-policies
 fi
 
 echo "Deploying namespace..."


### PR DESCRIPTION
This PR adds a `kubectl wait` command to wait for pss policies to be ready before proceeding, otherwise the load test could be spun up while Kyverno reconciles policy statuses.