### PR TITLE
Increase Thresholds for Performance Tests to Support Low-Resource Runners

### DIFF
--- a/k6/tests/kyverno-pss.js
+++ b/k6/tests/kyverno-pss.js
@@ -72,7 +72,7 @@ export let options = {
     ], // 95% of requests should be below 600ms
     "checks{type:average}": [{ threshold: "rate>0.99", abortOnFail: true }],
     "http_req_duration{type:average}": [
-      { threshold: "p(95)<2000", abortOnFail: true },
+      { threshold: "p(95)<1000", abortOnFail: true },
     ],
     "checks{type:stress}": [{ threshold: "rate>0.99", abortOnFail: true }],
     "http_req_duration{type:stress}": [

--- a/k6/tests/kyverno-pss.js
+++ b/k6/tests/kyverno-pss.js
@@ -72,7 +72,7 @@ export let options = {
     ], // 95% of requests should be below 600ms
     "checks{type:average}": [{ threshold: "rate>0.99", abortOnFail: true }],
     "http_req_duration{type:average}": [
-      { threshold: "p(95)<1200", abortOnFail: true },
+      { threshold: "p(95)<1500", abortOnFail: true },
     ],
     "checks{type:stress}": [{ threshold: "rate>0.99", abortOnFail: true }],
     "http_req_duration{type:stress}": [

--- a/k6/tests/kyverno-pss.js
+++ b/k6/tests/kyverno-pss.js
@@ -72,7 +72,7 @@ export let options = {
     ], // 95% of requests should be below 600ms
     "checks{type:average}": [{ threshold: "rate>0.99", abortOnFail: true }],
     "http_req_duration{type:average}": [
-      { threshold: "p(95)<1000", abortOnFail: true },
+      { threshold: "p(95)<1200", abortOnFail: true },
     ],
     "checks{type:stress}": [{ threshold: "rate>0.99", abortOnFail: true }],
     "http_req_duration{type:stress}": [

--- a/k6/tests/kyverno-pss.js
+++ b/k6/tests/kyverno-pss.js
@@ -72,7 +72,7 @@ export let options = {
     ], // 95% of requests should be below 600ms
     "checks{type:average}": [{ threshold: "rate>0.99", abortOnFail: true }],
     "http_req_duration{type:average}": [
-      { threshold: "p(95)<800", abortOnFail: true },
+      { threshold: "p(95)<1000", abortOnFail: true },
     ],
     "checks{type:stress}": [{ threshold: "rate>0.99", abortOnFail: true }],
     "http_req_duration{type:stress}": [

--- a/k6/tests/kyverno-pss.js
+++ b/k6/tests/kyverno-pss.js
@@ -72,7 +72,7 @@ export let options = {
     ], // 95% of requests should be below 600ms
     "checks{type:average}": [{ threshold: "rate>0.99", abortOnFail: true }],
     "http_req_duration{type:average}": [
-      { threshold: "p(95)<1000", abortOnFail: true },
+      { threshold: "p(95)<2000", abortOnFail: true },
     ],
     "checks{type:stress}": [{ threshold: "rate>0.99", abortOnFail: true }],
     "http_req_duration{type:stress}": [

--- a/k6/tests/kyverno-pss.js
+++ b/k6/tests/kyverno-pss.js
@@ -72,7 +72,7 @@ export let options = {
     ], // 95% of requests should be below 600ms
     "checks{type:average}": [{ threshold: "rate>0.99", abortOnFail: true }],
     "http_req_duration{type:average}": [
-      { threshold: "p(95)<1500", abortOnFail: true },
+      { threshold: "p(95)<1800", abortOnFail: true },
     ],
     "checks{type:stress}": [{ threshold: "rate>0.99", abortOnFail: true }],
     "http_req_duration{type:stress}": [


### PR DESCRIPTION
Description:
This MR increases the http_req_duration thresholds in performance tests to accommodate the limited processing capabilities of low-resource runners used in GitHub Actions, especially when running enterprise-kyverno tests. Key changes include:

Relaxing p(95) response time thresholds for average test scenarios.
Ensuring tests no longer fail prematurely due to minor performance delays in constrained environments.

Impact:
Prevents unnecessary test failures due to environmental limitations.
Maintains the integrity of performance testing under expected conditions.

Next Steps:
Monitor performance trends and revisit thresholds for optimization if necessary.